### PR TITLE
fix: message wrapping for long messages

### DIFF
--- a/rust/client/src/ui.rs
+++ b/rust/client/src/ui.rs
@@ -1,11 +1,11 @@
 use crate::app::{App, InputMode};
-use chrono::{Local, Utc, TimeZone};
+use chrono::{Local, TimeZone, Utc};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Position},
     style::{Color, Modifier, Style, Stylize},
     text::{Line, Span, Text},
-    widgets::{Block, List, ListItem, Paragraph},
+    widgets::{Block, List, ListItem, Paragraph, Wrap},
 };
 
 pub fn draw(app: &mut App, frame: &mut Frame) {
@@ -65,19 +65,23 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
     let start = full_messages.len().saturating_sub(height - 2 + app.scroll);
     let visible = &full_messages[start..];
 
-    let communication: Vec<ListItem> = visible
+    let communication: Vec<Line> = visible
         .iter()
         .map(|m| {
-            let content = Line::from(Span::raw(format!(
+            Line::from(Span::raw(format!(
                 "<{}> {}: {}",
-                Utc.timestamp_opt(m.unixtime as i64, 0).unwrap().with_timezone(&Local).format("%H:%M"),
+                Utc.timestamp_opt(m.unixtime as i64, 0)
+                    .unwrap()
+                    .with_timezone(&Local)
+                    .format("%H:%M"),
                 m.username,
                 m.message.clone().unwrap_or_default()
-            )));
-            ListItem::new(content)
+            )))
         })
         .collect();
 
-    let communication = List::new(communication).block(Block::bordered().title("Messages"));
+    let communication = Paragraph::new(communication)
+        .block(Block::bordered().title("Messages"))
+        .wrap(Wrap { trim: true });
     frame.render_widget(communication, messages_area);
 }


### PR DESCRIPTION
Absolutes Skill Issue...

Scrolling funktioniert weiterhin ohne Probleme - entgegen aller Erwartungen

Dachte die Formatierung ist kacke, weil ich immer als nachricht Zeichen gespammt hat und dann ein Zeilenumbruch direkt nach Client: enforct wurde (beim letzten Leerzeichen). Bei normalen Nachrichten funktioniert es wie man es erwartet...
<img width="464" height="235" alt="image" src="https://github.com/user-attachments/assets/4ec374bf-6b2f-439d-82d9-23dd41608f36" />
